### PR TITLE
check for index before removal

### DIFF
--- a/pqueue.go
+++ b/pqueue.go
@@ -87,6 +87,8 @@ func (pq *PQueue) Pop() (interface{}, int64) {
 	var max *Item = pq.items[1]
 
 	pq.exch(1, pq.size())
+
+	pq.items[pq.size()].index=-1 //if the item has being removed with pop, we mark it so that it cant be removed again with remove()
 	pq.items[pq.size()] = nil	// Free the space
 	pq.items = pq.items[0:pq.size()]
 	pq.elemsCount -= 1
@@ -129,10 +131,9 @@ func (pq *PQueue) Remove(i *Item) bool {
 	pq.Lock()
 	defer pq.Unlock()
 
-	if pq.size() < 1 {
+	if pq.size() < 1 || i.index == -1{
 		return false
 	}
-
 	if pq.size() > i.index+1 {
 		pq.items = append(pq.items[:i.index], pq.items[i.index+1:len(pq.items)]...)
 	} else {


### PR DESCRIPTION
Currently, push() returns an item struct with a given index, and remove() uses the index in the struct to remove the item. However, if the item has already been removed using pop() it can still be removed again and will cause discrepancies in pq size and the actual elements in the array.